### PR TITLE
rm airflow dependencies - hook, context, operator

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,23 @@
 stages:
+  - build
   - test
+
+variables:
+  GIT_DEPTH: "3"
+  IMAGE_LABELS: >
+    --label vcs-url=$CI_PROJECT_URL
+    --label com.skypicker.gitlab.ci.builder=$GITLAB_USER_EMAIL
+    --label com.skypicker.gitlab.ci.pipeline=$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID
+    --label com.skypicker.gitlab.ci.ref=$CI_BUILD_REF_NAME
+    --label com.skypicker.gitlab.ci.build=$CI_PROJECT_URL/builds/$CI_BUILD_ID
+
+image: docker:18.06
+
+before_script:
+  - docker login -u $CI_REGISTRY_USER -p $CI_JOB_TOKEN $CI_REGISTRY || true
+
+include:
+  - 'https://ci-files.skypicker.com/templates/build/black.yml'
 
 test:pytest:
   image: python:3.6

--- a/contessa/__init__.py
+++ b/contessa/__init__.py
@@ -7,7 +7,7 @@ check on load in temporary table.
 """
 
 # Start ignoring PyUnusedCodeBear
-from .operator import DataQualityOperator
+from .runner import ContessaRunner
 from .rules import EQ, GT, GTE, LT, LTE, NOT, NOT_COLUMN, NOT_NULL, SQL
 
 # Stop ignoring

--- a/contessa/base_rules.py
+++ b/contessa/base_rules.py
@@ -5,7 +5,7 @@ class Rule(metaclass=abc.ABCMeta):
     """
     Representation of one rule.
     Method apply define how it will be evaluated using the executor that will inject all the
-    needed attributes to apply it (df, hook etc.).
+    needed attributes to apply it (df, connector etc.).
 
     Attributes:
         executor_cls    Executor, indication of which executor class can execute this rule

--- a/contessa/db.py
+++ b/contessa/db.py
@@ -1,0 +1,40 @@
+from typing import Union
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine.base import Engine
+import pandas.io.sql as pdsql
+
+
+class Connector:
+    """
+    Wrapping sqlachemy engine. Holds some useful methods.
+    """
+
+    def __init__(self, conn_uri_or_engine: Union[str, Engine]):
+        if isinstance(conn_uri_or_engine, str):
+            self.engine = create_engine(conn_uri_or_engine)
+        elif isinstance(conn_uri_or_engine, Engine):
+            self.engine = conn_uri_or_engine
+        else:
+            cls_name = self.__class__.__name__
+            raise ValueError(
+                f"You can only pass conn str or sqlalchemy `Engine` to `{cls_name}`."
+            )
+
+    def get_records(self, sql, params=None):
+        """
+        Just proxy with better name if used.
+        """
+        return self.execute(sql, params)
+
+    def execute(self, sql, params=None):
+        """
+        Execute sql, if there are some results, return them.
+        """
+        params = params or {}
+        with self.engine.connect() as conn:
+            rs = conn.execute(sql, **params)
+        return rs
+
+    def get_pandas_df(self, sql):
+        return pdsql.read_sql(sql, con=self.engine)

--- a/contessa/rules.py
+++ b/contessa/rules.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from contessa.base_rules import Rule
+from contessa.db import Connector
 from contessa.executor import get_executor, SqlExecutor
 
 
@@ -55,15 +56,14 @@ class SqlRule(Rule):
         where_time_filter = e.compose_where_filter(self)
         return f"{self.format_sql()} {where_time_filter}"
 
-    def apply(self, hook):
+    def apply(self, conn: Connector):
         """
-        Execute a formatted sql using hook. Check if it returns list of booleans that is needed
+        Execute a formatted sql. Check if it returns list of booleans that is needed
         to do a quality check. If yes, return pd.Series.
-        :param hook: DbApiHook, mostly PostgresHook
         :return: pd.Series
         """
         sql = self.sql_with_time_filter
-        results = hook.get_records(sql)
+        results = conn.get_records(sql)
         is_list_of_bool = all(
             (len(r) == 1 and isinstance(r[0], (bool, type(None))) for r in results)
         )


### PR DESCRIPTION
I have removed hook, context and operator. 

Introduced **Connector** and **ContessaRunner**. I didn't like the **Hook** name as we associate it too much with airflow, but if you've never worked with it, its not exact in terms of meaning.

Tests would probably fail a lot, need to be adjusted and checked, probably in the next MR.

closes #2 