### PR TITLE
Add support for different check & quality tables from different schem…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,70 @@
 
 Data-quality framework
 
+# Short usage
+
+```python
+from contessa import ContessaRunner, NOT_NULL, GT, SQL
+no_bags_sql = """
+	SELECT CASE WHEN is_no_bags_booking = 'T' AND bags > 0 THEN false ELSE true END
+	FROM {{table_fullname}};
+"""
+contessa = ContessaRunner("postgres://:@localhost:5432")
+
+RULES = [
+	{
+        "name": NOT_NULL,
+        "columns": ["status", "market", "src", "dst"], 
+    },
+    {
+        "name": GT,
+        "value": 0,
+        "columns": ["initial_price", "turnover_before_refunds", ],
+    },
+    {
+        "name": SQL,
+        "sql": no_bags_sql,
+        "description": "No bags booking should have bags = 0",
+    },
+]
+ts_nodash = "20191010T101010"  # should be set dynamically (e.g. by airflow), just example here
+contessa.run(
+	raw_rules=RULES,
+	check_table={"schema_name": "temporary", "table_name": f"my_table_{ts_nodash}"},
+	result_table={"schema_name": "dq", "table_name": "my_table"},
+)
+```
+
+This will result in table `dq.quality_check_my_table` with each row looking like:
+
+```python
+class QualityCheck:
+    id = Column(BIGINT, primary_key=True)
+    attribute = Column(TEXT)
+    rule_name = Column(TEXT)
+    rule_description = Column(TEXT)
+    total_records = Column(INTEGER)
+
+    failed = Column(INTEGER)
+    median_30_day_failed = Column(DOUBLE_PRECISION)
+    failed_percentage = Column(DOUBLE_PRECISION)
+
+    passed = Column(INTEGER)
+    median_30_day_passed = Column(DOUBLE_PRECISION)
+    passed_percentage = Column(DOUBLE_PRECISION)
+
+    status = Column(TEXT)
+    time_filter = Column(TEXT)
+    task_ts = Column(TIMESTAMP(timezone=True), nullable=False, index=True)
+    created_at = Column(
+        DateTime(timezone=True),
+        server_default=text("NOW()"),
+        nullable=False,
+        index=True,
+    )
+
+```
+
 # How to run tests
 
 ```bash
@@ -15,8 +79,11 @@ In case of unit tests (you do not need db):
 $ pytest test/unit/test_operator.py
 ```
 
-# context
+# Context
+
+Each run has its own context, mostly used for templating the final sql. This is its context: 
 
 {
-	"table_fullname" : "public.booking_all_v2"
+	"table_fullname" : "public.my_cool_table"
+	"task_ts": passed by client or datetime.now()
 }

--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ In case of unit tests (you do not need db):
 ```
 $ pytest test/unit/test_operator.py
 ```
+
+# context
+
+{
+	"table_fullname" : "public.booking_all_v2"
+}

--- a/contessa/executor.py
+++ b/contessa/executor.py
@@ -1,7 +1,7 @@
 import abc
 from datetime import datetime, timedelta
 import logging
-from typing import Optional, Dict
+from typing import Dict
 
 import pandas as pd
 
@@ -17,13 +17,10 @@ class Executor(metaclass=abc.ABCMeta):
 
     date_columns = ("created_at", "updated_at", "confirmed_at")
 
-    def __init__(
-        self, check_table: Table, conn: Connector, context: Optional[Dict] = None
-    ):
+    def __init__(self, check_table: Table, conn: Connector, context: Dict):
         self.conn = conn
         self.check_table = check_table
-
-        self.context = context or {}
+        self.context = context
         self._raw_df = None
 
     def matched_cols(self, cols):
@@ -32,12 +29,10 @@ class Executor(metaclass=abc.ABCMeta):
                 yield col
 
     def get_context(self):
-        ctx = {
-            "table_fullname": self.check_table.fullname,
-            # todo - provide some defaults if self.context is none, e.g. time
-        }
-        ctx.update(self.context)
-        return ctx
+        """
+        Hook for adding something to context specific for Executor. (don't forget to call super)
+        """
+        return self.context
 
     @property
     def raw_df(self):
@@ -126,9 +121,7 @@ class SqlExecutor(Executor):
 executors = None
 
 
-def refresh_executors(
-    check_table: Table, conn: Connector, context: Optional[Dict] = None
-):
+def refresh_executors(check_table: Table, conn: Connector, context: Dict):
     """
     Use this to re-init the executor classes that are used to execute rules. To have right
     data from new table in Executor class.

--- a/contessa/models.py
+++ b/contessa/models.py
@@ -146,25 +146,34 @@ class Table:
         return f"{self.schema_name}.{self.table_name}"
 
 
-class QualityTable(Table):
-    def __init__(self, schema_name, table_name, quality_name=None):
+class ResultTable(Table):
+    """
+    Name will be constructed as "quality_check_{table_name}", e.g. "quality_check_my_table".
+    Can be overridden by `result_table_name`.
+    """
+
+    def __init__(self, schema_name, table_name, result_table_name=None):
         super().__init__(schema_name, table_name)
-        self.quality_name = quality_name
+        self.result_table_name = result_table_name
 
     @property
     def fullname(self):
         # todo - test this
-        if self.quality_name:
-            return self.quality_name
+        if self.result_table_name:
+            return self.result_table_name
         return f"quality_check_{self.table_name}"
 
     @property
     def clsname(self):
+        """
+        Construct a name for dynamic creation of cls for quality table.
+        Should be unique in runtime.
+        """
         name = super().fullname.replace(".", "")
         return f"{name.capitalize()}QualityCheck"
 
 
-def get_default_qc_class(result_table: QualityTable):
+def get_default_qc_class(result_table: ResultTable):
     """
     This will construct type/class (not object) that will have special name that its prefixed
     with its table. It's better because sqlalchemy can yell somethings if we would use same class

--- a/contessa/normalizer.py
+++ b/contessa/normalizer.py
@@ -26,27 +26,30 @@ class RuleNormalizer:
 
     """
 
-    def normalize(self, rules_def):
+    @classmethod
+    def normalize(cls, rules_def):
         normalized = []
         for rule_def in rules_def:
             # if it is normalized, we skip it
-            if not self._should_normalize(rule_def):
+            if not cls._should_normalize(rule_def):
                 normalized.append(rule_def)
                 continue
             # otherwise we split all the permutations of lists into separate rules
-            permutations = self._get_permutations(rule_def)
-            new_rules = self._split_permutations(permutations, rule_def)
+            permutations = cls._get_permutations(rule_def)
+            new_rules = cls._split_permutations(permutations, rule_def)
             normalized.extend(new_rules)
         return normalized
 
-    def _should_normalize(self, rule_def):
+    @staticmethod
+    def _should_normalize(rule_def):
         if "columns" in rule_def:
             return True
         elif "time_filters" in rule_def and len(rule_def["time_filters"]) > 1:
             return True
         return False
 
-    def _get_permutations(self, rule_def):
+    @staticmethod
+    def _get_permutations(rule_def):
         cols = rule_def.get("columns") or [rule_def.get("column")] or [None]
         time_filters = (
             rule_def.get("time_filters") or [rule_def.get("time_filter")] or [None]
@@ -54,7 +57,8 @@ class RuleNormalizer:
         permutations = itertools.product(cols, time_filters)
         return permutations
 
-    def _split_permutations(self, permutations, rule_def):
+    @staticmethod
+    def _split_permutations(permutations, rule_def):
         new_rules = []
         for perm in permutations:
             tmp = rule_def.copy()

--- a/contessa/rules.py
+++ b/contessa/rules.py
@@ -7,18 +7,15 @@ from contessa.executor import get_executor, SqlExecutor
 
 class SqlRule(Rule):
     """
-    Rule that executes a custom sql that is written by anyone.
-    It can use variable `tmp_table_name`
-
-    :param name: str
-    :param sql: str, SQL to execute
+    Rule that executes a custom sql that is custom written.
+    It can use context from Executor.get_context
     """
 
     executor_cls = SqlExecutor
 
     def get_sql_parameters(self):
         e = get_executor(self.__class__)
-        return e.context()
+        return e.get_context()
 
     @property
     def sql(self):
@@ -112,7 +109,7 @@ class NotNullRule(OneColumnRuleSQL):
     @property
     def sql(self):
         return f"""
-            SELECT {{target_column}} IS NOT NULL FROM {{table_name}}
+            SELECT {{target_column}} IS NOT NULL FROM {{table_fullname}}
         """
 
 
@@ -126,7 +123,7 @@ class GtRule(OneColumnRuleSQL):
     @property
     def sql(self):
         return f"""
-            SELECT {{target_column}} > {self.value} FROM {{table_name}}
+            SELECT {{target_column}} > {self.value} FROM {{table_fullname}}
         """
 
 
@@ -140,7 +137,7 @@ class GteRule(OneColumnRuleSQL):
     @property
     def sql(self):
         return f"""
-            SELECT {{target_column}} >= {self.value} FROM {{table_name}}
+            SELECT {{target_column}} >= {self.value} FROM {{table_fullname}}
         """
 
 
@@ -155,7 +152,7 @@ class NotRule(OneColumnRuleSQL):
     def sql(self):
         return f"""
             SELECT {{target_column}} is distinct from {self.value}
-            FROM {{table_name}}
+            FROM {{table_fullname}}
         """
 
 
@@ -172,7 +169,7 @@ class NotColumnRule(OneColumnRuleSQL):
     def sql(self):
         return f"""
             SELECT {{target_column}} is distinct from {self.column2}
-            FROM {{table_name}}
+            FROM {{table_fullname}}
         """
 
 
@@ -186,7 +183,7 @@ class LtRule(OneColumnRuleSQL):
     @property
     def sql(self):
         return f"""
-            SELECT {{target_column}} < {self.value} FROM {{table_name}}
+            SELECT {{target_column}} < {self.value} FROM {{table_fullname}}
         """
 
 
@@ -200,7 +197,7 @@ class LteRule(OneColumnRuleSQL):
     @property
     def sql(self):
         return f"""
-            SELECT {{target_column}} <= {self.value} FROM {{table_name}}
+            SELECT {{target_column}} <= {self.value} FROM {{table_fullname}}
         """
 
 
@@ -214,7 +211,7 @@ class EqRule(OneColumnRuleSQL):
     @property
     def sql(self):
         return f"""
-            SELECT {{target_column}} IS NOT DISTINCT FROM {self.value} FROM {{table_name}}
+            SELECT {{target_column}} IS NOT DISTINCT FROM {self.value} FROM {{table_fullname}}
         """
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -24,3 +24,8 @@ def rule():
 @pytest.fixture(scope="session")
 def results():
     return pd.Series([True, True, False, False, True], name="src")
+
+
+@pytest.fixture(scope="session")
+def ctx():
+    return {"task_ts": FakedDatetime.now(), "table_fullname": "public.tmp_table"}

--- a/test/integration/test_executor.py
+++ b/test/integration/test_executor.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from contessa.executor import Executor
+from contessa.models import Table
 from contessa.rules import NotNullRule
 from test.conftest import FakedDatetime
 
@@ -34,7 +35,7 @@ def e(conn):
         def compose_kwargs(self, rule):
             return {}
 
-    return ConcreteExecutor("tmp", "hello_world", conn)
+    return ConcreteExecutor(Table("tmp", "hello_world"), conn)
 
 
 def test_executor_raw_df(e):

--- a/test/integration/test_executor.py
+++ b/test/integration/test_executor.py
@@ -30,12 +30,12 @@ def db(conn):
 
 
 @pytest.fixture
-def e(conn):
+def e(conn, ctx):
     class ConcreteExecutor(Executor):
         def compose_kwargs(self, rule):
             return {}
 
-    return ConcreteExecutor(Table("tmp", "hello_world"), conn)
+    return ConcreteExecutor(Table("tmp", "hello_world"), conn, ctx)
 
 
 def test_executor_raw_df(e):

--- a/test/integration/test_models.py
+++ b/test/integration/test_models.py
@@ -3,13 +3,13 @@ import datetime
 from contessa.db import Connector
 from test.conftest import FakedDatetime
 
-from contessa.models import get_default_qc_class, QualityTable, DQBase
+from contessa.models import get_default_qc_class, ResultTable, DQBase
 
 
 def test_quality_check_init_row(rule, results, conn: Connector):
     DQBase.metadata.clear()
     qc = get_default_qc_class(
-        QualityTable(schema_name="data_quality", table_name="booking")
+        ResultTable(schema_name="data_quality", table_name="booking")
     )
     assert qc.__tablename__ == "quality_check_booking"
     assert qc.__name__ == "Data_qualitybookingQualityCheck"
@@ -36,7 +36,7 @@ def test_quality_check_init_row(rule, results, conn: Connector):
 
 def test_set_medians(conn: Connector, monkeypatch):
     DQBase.metadata.clear()
-    qc = get_default_qc_class(QualityTable(schema_name="data_quality", table_name="t"))
+    qc = get_default_qc_class(ResultTable(schema_name="data_quality", table_name="t"))
     qc.__table__.create(conn.engine)
     instance = qc()
 

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -149,14 +149,18 @@ class TestDataQualityOperator(unittest.TestCase):
         ]
         self.contessa_runner.run(
             check_table={"schema_name": "tmp", "table_name": self.tmp_table_name},
-            result_table={"schema_name": "data_quality", "table_name": self.table_name},
+            result_table={
+                "schema_name": "data_quality",
+                "table_name": self.table_name,
+                "result_table_name": "abcde",
+            },
             raw_rules=rules,
             context={"task_ts": self.now},
         )
 
         rows = self.conn.get_pandas_df(
             f"""
-            SELECT * from data_quality.quality_check_{self.table_name}
+            SELECT * from data_quality.abcde
             order by created_at
         """
         )

--- a/test/unit/test_executor.py
+++ b/test/unit/test_executor.py
@@ -3,19 +3,22 @@ from datetime import datetime
 import pandas as pd
 
 from contessa.executor import PandasExecutor, SqlExecutor
+from contessa.models import Table
 from contessa.rules import NotNullRule
 
 
 def test_compose_kwargs_sql_executor(dummy_contessa):
-    e = SqlExecutor("tmp", "hello_world", dummy_contessa.conn)
+    t = Table(**{"schema_name": "tmp", "table_name": "hello_world"})
+    e = SqlExecutor(t, dummy_contessa.conn)
     rule = NotNullRule("not_null", "src", time_filter="created_at")
     kwargs = e.compose_kwargs(rule)
     expected = {"conn": dummy_contessa.conn}
     assert kwargs == expected
 
 
-def test_compose_kwargs_pd_executor(dummy_contessa, monkeypatch):
-    e = PandasExecutor("tmp", "hello_world", dummy_contessa.conn)
+def test_compose_kwargs_pd_executor(dummy_contessa):
+    t = Table(**{"schema_name": "tmp", "table_name": "hello_world"})
+    e = PandasExecutor(t, dummy_contessa.conn)
     rule = NotNullRule("not_null", "src", time_filter="created_at")
     df = pd.DataFrame([{"created_at": datetime(2017, 10, 10)}])
     e.conn.get_pandas_df = lambda x: df

--- a/test/unit/test_executor.py
+++ b/test/unit/test_executor.py
@@ -7,18 +7,18 @@ from contessa.models import Table
 from contessa.rules import NotNullRule
 
 
-def test_compose_kwargs_sql_executor(dummy_contessa):
+def test_compose_kwargs_sql_executor(dummy_contessa, ctx):
     t = Table(**{"schema_name": "tmp", "table_name": "hello_world"})
-    e = SqlExecutor(t, dummy_contessa.conn)
+    e = SqlExecutor(t, dummy_contessa.conn, ctx)
     rule = NotNullRule("not_null", "src", time_filter="created_at")
     kwargs = e.compose_kwargs(rule)
     expected = {"conn": dummy_contessa.conn}
     assert kwargs == expected
 
 
-def test_compose_kwargs_pd_executor(dummy_contessa):
+def test_compose_kwargs_pd_executor(dummy_contessa, ctx):
     t = Table(**{"schema_name": "tmp", "table_name": "hello_world"})
-    e = PandasExecutor(t, dummy_contessa.conn)
+    e = PandasExecutor(t, dummy_contessa.conn, ctx)
     rule = NotNullRule("not_null", "src", time_filter="created_at")
     df = pd.DataFrame([{"created_at": datetime(2017, 10, 10)}])
     e.conn.get_pandas_df = lambda x: df

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -1,5 +1,6 @@
 import pytest
 
+from contessa.models import QualityTable
 from contessa.rules import GtRule, NotNullRule
 
 
@@ -36,6 +37,6 @@ def test_not_known_rule(dummy_contessa):
 
 def test_generic_typ_qc_class(dummy_contessa):
     assert (
-        dummy_contessa.get_quality_check_class("mytable").__name__
-        == "MytableQualityCheck"
+        dummy_contessa.get_quality_check_class(QualityTable("tmp", "mytable")).__name__
+        == "TmpmytableQualityCheck"
     )

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -1,6 +1,6 @@
 import pytest
 
-from contessa.models import QualityTable
+from contessa.models import ResultTable
 from contessa.rules import GtRule, NotNullRule
 
 
@@ -37,6 +37,6 @@ def test_not_known_rule(dummy_contessa):
 
 def test_generic_typ_qc_class(dummy_contessa):
     assert (
-        dummy_contessa.get_quality_check_class(QualityTable("tmp", "mytable")).__name__
+        dummy_contessa.get_quality_check_class(ResultTable("tmp", "mytable")).__name__
         == "TmpmytableQualityCheck"
     )


### PR DESCRIPTION
Need to write more tests + docs.

But pls review, should change API a bit and solve this:
- check table and quality table can be different schema or name
- is not bound to any context

related closes #9 

This should allow to write an Airflow operator that should have all the Airflow logic. 