### PR TITLE
Extend time filter format

### DIFF
--- a/contessa/executor.py
+++ b/contessa/executor.py
@@ -76,15 +76,17 @@ class Executor(metaclass=abc.ABCMeta):
             elif isinstance(rule.time_filter, list):
                 for each in rule.time_filter:
                     filters.append(
-                        {"column": each.get("column"), "days": each.get("days", days)}
+                        {"column": each["column"], "days": each.get("days", days)}
                     )
 
             for each in filters:
+                present = self.context["task_ts"].strftime("%Y-%m-%d %H:%M:%S UTC")
                 past = (
-                    self.context.get("task_ts", datetime.now())
-                    - timedelta(days=each["days"])
+                    self.context["task_ts"] - timedelta(days=each["days"])
                 ).strftime("%Y-%m-%d %H:%M:%S UTC")
-                result.append(f"""{each["column"]} >= '{past}'::timestamp""")
+                result.append(
+                    f"""{each["column"]} BETWEEN '{past}'::timestamptz AND '{present}'::timestamptz"""
+                )
 
         return " AND ".join(result)
 

--- a/contessa/executor.py
+++ b/contessa/executor.py
@@ -28,12 +28,6 @@ class Executor(metaclass=abc.ABCMeta):
             if col in self.date_columns:
                 yield col
 
-    def get_context(self):
-        """
-        Hook for adding something to context specific for Executor. (don't forget to call super)
-        """
-        return self.context
-
     @property
     def raw_df(self):
         """

--- a/contessa/models.py
+++ b/contessa/models.py
@@ -85,7 +85,7 @@ class QualityCheck(AbstractConcreteBase, DQBase):
             raise ValueError("In results of rule.apply can't be any Null values.")
 
         # todo - add to doc
-        self.task_ts = context.get("task_ts", None) or datetime.now()
+        self.task_ts = context["task_ts"]
         self.attribute = rule.attribute
         self.rule_name = rule.name
         self.rule_description = rule.description

--- a/contessa/normalizer.py
+++ b/contessa/normalizer.py
@@ -47,9 +47,7 @@ class RuleNormalizer:
             return True
         elif "separate_time_filters" in rule_def:
             if len(rule_def["separate_time_filters"]) <= 1:
-                logging.error(
-                    "Please use `time_filter` for one column, converting for now."
-                )
+                raise ValueError("Please use `time_filter` for one column.")
             return True
         return False
 
@@ -68,10 +66,15 @@ class RuleNormalizer:
     def _split_permutations(permutations, rule_def):
         new_rules = []
         for perm in permutations:
+            # time_filter has to be one of list, str or None
+            if isinstance(perm[1], dict):
+                time_filter = [perm[1]]
+            else:
+                time_filter = perm[1]
             tmp = rule_def.copy()
             tmp["column"] = perm[0]
             tmp.pop("columns", None)
-            tmp["time_filter"] = perm[1]
+            tmp["time_filter"] = time_filter
             tmp.pop("separate_time_filters", None)
             new_rules.append(tmp)
         return new_rules

--- a/contessa/rules.py
+++ b/contessa/rules.py
@@ -9,14 +9,14 @@ from contessa.executor import get_executor, SqlExecutor
 class SqlRule(Rule):
     """
     Rule that executes a custom sql that is custom written.
-    It can use context from Executor.get_context
+    It can use context from Executor.
     """
 
     executor_cls = SqlExecutor
 
     def get_sql_parameters(self):
         e = get_executor(self.__class__)
-        return e.get_context()
+        return e.context
 
     @property
     def sql(self):

--- a/contessa/runner.py
+++ b/contessa/runner.py
@@ -49,7 +49,6 @@ class ContessaRunner:
     def get_context(check_table: Table, context: Optional[Dict] = None) -> Dict:
         """
         Construct context to pass to executors. User context overrides defaults.
-        note: could be overridden in Executor.get_context() method.
         """
         ctx_defaults = {
             "table_fullname": check_table.fullname,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ CONTESSA CHANGELOG
 2019-XX-XX; 0.2.0;
 --------------------------------------------
 - refactor rules to use jinja2 as templating system
+- allow to configure time interval in `time_filter`
 
 
 2019-09-04; 0.1.3;

--- a/docs/time_filter.rst
+++ b/docs/time_filter.rst
@@ -1,0 +1,48 @@
+Filtering based on time
+==============================
+
+Each rule can define also time interval for selection of suitable rows with parameter **time_filter**.
+It expects at least name of the column, optionally also length of the interval in *days* (with default 30).
+It is possible to name multiple time-based columns.
+
+Format
+------------------------------
+
+.. code-block:: json
+
+    {
+        ...
+        "time_filter": [
+            {"column": "a", "days": 10},
+            {"column": "b", "days": 24},
+        ],
+    }
+
+How it works
+------------------------------
+
+Internally is this parameter used for constructing `WHERE` clause, with *task_ts* and (*task_ts* - *days*) as
+interval borders. In case multiple columns are named, all would be joined with `AND` - therefore only rows which satisfy
+all conditions at the same time will be eligible for further checking.
+
+
+Miscellaneous
+------------------------------
+
+ - For backward-compatibility is also supported simple format, which defines only name of the column. In this case default
+(30) for *days* is used.
+
+.. code-block:: json
+
+    "time_filter": "a"
+
+ - Parallel to **columns** shortcut for defining multiple rules at once, parameter **separate_time_filters** is available.
+   Each one will be used separately. In case both *separate_time_filters* and *time_filter* are defined, only
+   *separate_time_filters* would be considered.
+
+.. code-block:: json
+
+    "separate_time_filters": [{"column": "c"}, {"column": "d"}]}
+
+
+

--- a/test/unit/test_executor.py
+++ b/test/unit/test_executor.py
@@ -25,7 +25,7 @@ def test_compose_kwargs_sql_executor_time_filter(dummy_contessa, ctx):
     computed_datetime = (ctx["task_ts"] - timedelta(days=30)).strftime(
         "%Y-%m-%d %H:%M:%S"
     )
-    expected = f"created_at >= '{computed_datetime} UTC'::timestamp"
+    expected = f"created_at BETWEEN '{computed_datetime} UTC'::timestamptz AND '{ctx['task_ts']} UTC'::timestamptz"
     assert time_filter == expected, "time_filter is string"
 
     rule = NotNullRule("not_null", "src", time_filter=[{"column": "created_at"}])
@@ -33,7 +33,7 @@ def test_compose_kwargs_sql_executor_time_filter(dummy_contessa, ctx):
     computed_datetime = (ctx["task_ts"] - timedelta(days=30)).strftime(
         "%Y-%m-%d %H:%M:%S"
     )
-    expected = f"created_at >= '{computed_datetime} UTC'::timestamp"
+    expected = f"created_at BETWEEN '{computed_datetime} UTC'::timestamptz AND '{ctx['task_ts']} UTC'::timestamptz"
     assert time_filter == expected, "time_filter has only column"
 
     rule = NotNullRule(
@@ -52,8 +52,8 @@ def test_compose_kwargs_sql_executor_time_filter(dummy_contessa, ctx):
         "%Y-%m-%d %H:%M:%S"
     )
     expected = (
-        f"created_at >= '{computed_created} UTC'::timestamp AND "
-        f"updated_at >= '{computed_updated} UTC'::timestamp"
+        f"created_at BETWEEN '{computed_created} UTC'::timestamptz AND '{ctx['task_ts']} UTC'::timestamptz AND "
+        f"updated_at BETWEEN '{computed_updated} UTC'::timestamptz AND '{ctx['task_ts']} UTC'::timestamptz"
     )
     assert time_filter == expected, "time_filter has 2 members"
 

--- a/test/unit/test_normalizer.py
+++ b/test/unit/test_normalizer.py
@@ -33,10 +33,27 @@ from contessa.normalizer import RuleNormalizer
             ],
         ),
         (
-            [{"name": "not_null", "column": "a", "time_filters": ["a", "b"]}],
             [
-                {"name": "not_null", "column": "a", "time_filter": "a"},
-                {"name": "not_null", "column": "a", "time_filter": "b"},
+                {
+                    "name": "not_null",
+                    "column": "a",
+                    "time_filters": [
+                        {"column": "a", "days": 10},
+                        {"column": "b", "days": 5},
+                    ],
+                }
+            ],
+            [
+                {
+                    "name": "not_null",
+                    "column": "a",
+                    "time_filter": {"column": "a", "days": 10},
+                },
+                {
+                    "name": "not_null",
+                    "column": "a",
+                    "time_filter": {"column": "b", "days": 5},
+                },
             ],
         ),
         (
@@ -47,7 +64,7 @@ from contessa.normalizer import RuleNormalizer
 )
 def test_normalizer(rules_def, normalized):
     results = RuleNormalizer().normalize(rules_def)
-    op = operator.itemgetter("name", "column", "time_filter")
+    op = operator.itemgetter("name", "column")
     expected = sorted(normalized, key=op)
     results_sorted = sorted(results, key=op)
     assert expected == results_sorted

--- a/test/unit/test_normalizer.py
+++ b/test/unit/test_normalizer.py
@@ -13,7 +13,7 @@ from contessa.normalizer import RuleNormalizer
                 {
                     "name": "not_null",
                     "columns": ["a", "b", "c"],
-                    "time_filters": ["c", "u"],
+                    "separate_time_filters": ["c", "u"],
                 }
             ],
             [
@@ -33,11 +33,38 @@ from contessa.normalizer import RuleNormalizer
             ],
         ),
         (
+            [{"name": "not_null", "column": "a", "time_filter": "a"}],
+            [{"name": "not_null", "column": "a", "time_filter": "a"}],
+        ),
+    ],
+)
+def test_normalizer(rules_def, normalized):
+    results = RuleNormalizer().normalize(rules_def)
+    op = operator.itemgetter("name", "column", "time_filter")
+    expected = sorted(normalized, key=op)
+    results_sorted = sorted(results, key=op)
+    assert expected == results_sorted
+
+
+@pytest.mark.parametrize(
+    "rules_def, normalized",
+    [
+        (
             [
                 {
                     "name": "not_null",
                     "column": "a",
-                    "time_filters": [
+                    "separate_time_filters": [{"column": "c"}],
+                }
+            ],
+            [{"name": "not_null", "column": "a", "time_filter": {"column": "c"}}],
+        ),
+        (
+            [
+                {
+                    "name": "not_null",
+                    "column": "a",
+                    "separate_time_filters": [
                         {"column": "a", "days": 10},
                         {"column": "b", "days": 5},
                     ],
@@ -56,17 +83,13 @@ from contessa.normalizer import RuleNormalizer
                 },
             ],
         ),
-        (
-            [{"name": "not_null", "column": "a", "time_filter": "a"}],
-            [{"name": "not_null", "column": "a", "time_filter": "a"}],
-        ),
     ],
 )
-def test_normalizer(rules_def, normalized):
+def test_normalizer_separate_time_filters(rules_def, normalized):
     results = RuleNormalizer().normalize(rules_def)
-    op = operator.itemgetter("name", "column")
-    expected = sorted(normalized, key=op)
-    results_sorted = sorted(results, key=op)
+    key = lambda x: (x["name"], x["column"], x["time_filter"]["column"])
+    expected = sorted(normalized, key=key)
+    results_sorted = sorted(results, key=key)
     assert expected == results_sorted
 
 


### PR DESCRIPTION
Relates to #28
Rule parameter `time_filter` now accepts also number of days (with _30_ as default). It also allows to filter by multiple columns.
New format is:
```
"time_filter": [
     {"column": "a", "days": 10}, 
     {"column": "b", "days": 5}
]
```