### PR TITLE
name to type refactoring

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,16 +21,17 @@ Quick Example
 
     RULES = [
         {
-            "name": NOT_NULL,
+            "name" : "Status and market null check"
+            "type": NOT_NULL,
             "columns": ["status", "market", "src", "dst"], 
         },
         {
-            "name": GT,
+            "type": GT,
             "value": 0,
             "columns": ["initial_price", "turnover_before_refunds", ],
         },
         {
-            "name": SQL,
+            "type": SQL,
             "sql": no_bags_sql,
             "description": "No bags booking should have bags = 0",
         },

--- a/contessa/base_rules.py
+++ b/contessa/base_rules.py
@@ -12,6 +12,8 @@ class Rule(metaclass=abc.ABCMeta):
         description     str, description of the rule
 
     :param name: str
+    :param type: str
+    :param description: str
     :param time_filter: str
     :param condition: str
     """
@@ -19,8 +21,9 @@ class Rule(metaclass=abc.ABCMeta):
     executor_cls = None
     description = None
 
-    def __init__(self, name, description, time_filter=None, condition=None):
+    def __init__(self, name, type, description, time_filter=None, condition=None):
         self.name = name
+        self.type = type
         self.time_filter = time_filter
         self.condition = condition
         self.description = description
@@ -38,4 +41,4 @@ class Rule(metaclass=abc.ABCMeta):
 
     def __str__(self):
         tf = f"- {self.time_filter}" or ""
-        return f"Rule {self.name} {tf}"
+        return f"Rule {self.name} of type {self.type} {tf}"

--- a/contessa/models.py
+++ b/contessa/models.py
@@ -36,6 +36,7 @@ class QualityCheck(AbstractConcreteBase, DQBase):
     id = Column(BIGINT, primary_key=True)
     attribute = Column(TEXT)
     rule_name = Column(TEXT)
+    rule_type = Column(TEXT)
     rule_description = Column(TEXT)
     total_records = Column(INTEGER)
 
@@ -69,6 +70,7 @@ class QualityCheck(AbstractConcreteBase, DQBase):
             UniqueConstraint(
                 "attribute",
                 "rule_name",
+                "rule_type",
                 "task_ts",
                 "time_filter",
                 name=f"{cls.__tablename__}_unique_quality_check",
@@ -88,6 +90,7 @@ class QualityCheck(AbstractConcreteBase, DQBase):
         self.task_ts = context["task_ts"]
         self.attribute = rule.attribute
         self.rule_name = rule.name
+        self.rule_type = rule.type
         self.rule_description = rule.description
 
         self.total_records = results.shape[0]
@@ -134,7 +137,7 @@ class QualityCheck(AbstractConcreteBase, DQBase):
         self.median_30_day_passed = median(passed) if passed else None
 
     def __repr__(self):
-        return f"Rule ({self.attribute} - {self.rule_name} - {self.task_ts})"
+        return f"Rule ({self.attribute} - {self.rule_name} - {self.rule_type} - {self.task_ts})"
 
 
 # todo - maybe create also CheckTable

--- a/contessa/normalizer.py
+++ b/contessa/normalizer.py
@@ -8,16 +8,16 @@ class RuleNormalizer:
     one time_filter with provided where condition.
 
     Example:
-        {'name': 'not_null', 'columns': ['a', 'b', 'c'], 'separate_time_filters': ['c', 'u'], 'condition': 'd is TRUE'}
+        {'type': 'not_null', 'columns': ['a', 'b', 'c'], 'separate_time_filters': ['c', 'u'], 'condition': 'd is TRUE'}
 
         will be transformed to
 
-        {'name': 'not_null', 'column': 'a', 'time_filter': 'c', 'condition': 'd is TRUE'}
-        {'name': 'not_null', 'column': 'b', 'time_filter': 'c', 'condition': 'd is TRUE'}
-        {'name': 'not_null', 'column': 'c', 'time_filter': 'c', 'condition': 'd is TRUE'}
-        {'name': 'not_null', 'column': 'a', 'time_filter': 'u', 'condition': 'd is TRUE'}
-        {'name': 'not_null', 'column': 'b', 'time_filter': 'u', 'condition': 'd is TRUE'}
-        {'name': 'not_null', 'column': 'c', 'time_filter': 'u', 'condition': 'd is TRUE'}
+        {'type': 'not_null', 'column': 'a', 'time_filter': 'c', 'condition': 'd is TRUE'}
+        {'type': 'not_null', 'column': 'b', 'time_filter': 'c', 'condition': 'd is TRUE'}
+        {'type': 'not_null', 'column': 'c', 'time_filter': 'c', 'condition': 'd is TRUE'}
+        {'type': 'not_null', 'column': 'a', 'time_filter': 'u', 'condition': 'd is TRUE'}
+        {'type': 'not_null', 'column': 'b', 'time_filter': 'u', 'condition': 'd is TRUE'}
+        {'type': 'not_null', 'column': 'c', 'time_filter': 'u', 'condition': 'd is TRUE'}
 
     This class should define what we can support as an input to be able to make Rule classes
     from it. Currently it supports:

--- a/contessa/rules.py
+++ b/contessa/rules.py
@@ -72,7 +72,7 @@ class SqlRule(Rule):
         )
         if not is_list_of_bool:
             raise ValueError(
-                f"Your query for rule `{self.name}` does not return list of booleans or Nones."
+                f"Your query for rule `{self.name}` of type `{self.type}` does not return list of booleans or Nones."
             )
         return pd.Series([bool(r[0]) for r in results])
 
@@ -80,10 +80,10 @@ class SqlRule(Rule):
 class OneColumnRuleSQL(SqlRule):
     executor_cls = SqlExecutor
 
-    def __init__(self, name, column, description, **kwargs):
+    def __init__(self, name, type, column, description, **kwargs):
         if description == "" or description is None:
             raise TypeError("Description is mandatory")
-        super().__init__(name, description=description, **kwargs)
+        super().__init__(name, type, description=description, **kwargs)
         self.column = column
 
     @property
@@ -99,12 +99,12 @@ class OneColumnRuleSQL(SqlRule):
 
     def __str__(self):
         tf = f"- {self.time_filter}" or ""
-        return f"Rule {self.name} - {self.attribute} {tf}"
+        return f"Rule {self.name} - {self.type} - {self.attribute} {tf}"
 
 
 class CustomSqlRule(SqlRule):
-    def __init__(self, name, sql, description, **kwargs):
-        super().__init__(name, description=description, **kwargs)
+    def __init__(self, name, type, sql, description, **kwargs):
+        super().__init__(name, type, description=description, **kwargs)
         self.custom_sql = sql
 
     @property
@@ -113,8 +113,8 @@ class CustomSqlRule(SqlRule):
 
 
 class NotNullRule(OneColumnRuleSQL):
-    def __init__(self, name, column, description="True when data is null.", **kwargs):
-        super().__init__(name, column, description=description, **kwargs)
+    def __init__(self, name, type, column, description="True when data is null.", **kwargs):
+        super().__init__(name, type, column, description=description, **kwargs)
 
     @property
     def sql(self):
@@ -127,12 +127,13 @@ class GtRule(OneColumnRuleSQL):
     def __init__(
         self,
         name,
+        type,
         column,
         value,
         description="True when data is greater than input value.",
         **kwargs,
     ):
-        super().__init__(name, column, description=description, **kwargs)
+        super().__init__(name, type, column, description=description, **kwargs)
         self.value = value
 
     @property
@@ -146,12 +147,13 @@ class GteRule(OneColumnRuleSQL):
     def __init__(
         self,
         name,
+        type,
         column,
         value,
         description="True when data is greater or even than input value.",
         **kwargs,
     ):
-        super().__init__(name, column, description=description, **kwargs)
+        super().__init__(name, type, column, description=description, **kwargs)
         self.value = value
 
     @property
@@ -165,12 +167,13 @@ class NotRule(OneColumnRuleSQL):
     def __init__(
         self,
         name,
+        type,
         column,
         value,
         description="True when data is not input value.",
         **kwargs,
     ):
-        super().__init__(name, column, description=description, **kwargs)
+        super().__init__(name, type, column, description=description, **kwargs)
         self.value = value
 
     @property
@@ -185,12 +188,13 @@ class LtRule(OneColumnRuleSQL):
     def __init__(
         self,
         name,
+        type,
         column,
         value,
         description="True when data is less than input value.",
         **kwargs,
     ):
-        super().__init__(name, column, description=description, **kwargs)
+        super().__init__(name, type, column, description=description, **kwargs)
         self.value = value
 
     @property
@@ -204,12 +208,13 @@ class LteRule(OneColumnRuleSQL):
     def __init__(
         self,
         name,
+        type,
         column,
         value,
         description="True when data is less or even than input value.",
         **kwargs,
     ):
-        super().__init__(name, column, description=description, **kwargs)
+        super().__init__(name, type, column, description=description, **kwargs)
         self.value = value
 
     @property
@@ -223,12 +228,13 @@ class EqRule(OneColumnRuleSQL):
     def __init__(
         self,
         name,
+        type,
         column,
         value,
         description="True when data is the same as input value.",
         **kwargs,
     ):
-        super().__init__(name, column, description=description, **kwargs)
+        super().__init__(name, type, column, description=description, **kwargs)
         self.value = value
 
     @property
@@ -260,11 +266,11 @@ RULES = {
 }
 
 
-def get_rule_cls(name):
+def get_rule_cls(key):
     aval_rules = RULES.keys()
-    if name not in aval_rules:
+    if key not in aval_rules:
         raise ValueError(
-            f"I dont know this kind of rule - '{name}'. "
+            f"I dont know this kind of rule - '{key}'. "
             f"Possible rules are - {list(aval_rules)}"
         )
-    return RULES[name]
+    return RULES[key]

--- a/contessa/runner.py
+++ b/contessa/runner.py
@@ -129,11 +129,11 @@ class ContessaRunner:
 
     def pick_rule_cls(self, rule_def):
         """
-        Get rule class based on its name that was input by user.
+        Get rule class based on its type that was input by user.
         :param rule_def: dict
         :return: Rule class
         """
-        return get_rule_cls(rule_def["name"])
+        return get_rule_cls(rule_def["type"])
 
     def get_quality_check_class(self, result_table: ResultTable):
         """

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -9,16 +9,17 @@
 
     RULES = [
         {
-            "name": NOT_NULL,
+            "name" : "Status and market null check"
+            "type": NOT_NULL,
             "columns": ["status", "market", "src", "dst"], 
         },
         {
-            "name": GT,
+            "type": GT,
             "value": 0,
             "columns": ["initial_price", "turnover_before_refunds", ],
         },
         {
-            "name": SQL,
+            "type": SQL,
             "sql": no_bags_sql,
             "description": "No bags booking should have bags = 0",
         },

--- a/test/integration/test_rules.py
+++ b/test/integration/test_rules.py
@@ -206,8 +206,8 @@ def test_new_rule(conn, ctx):
     class CountSqlRule(SqlRule):
         executor_cls = SqlExecutor
 
-        def __init__(self, name, count, description=None, **kwargs):
-            super().__init__(name, description=description, **kwargs)
+        def __init__(self, name, type, count, description=None, **kwargs):
+            super().__init__(name, type, description=description, **kwargs)
             self.count = count
 
         def get_sql_parameters(self):

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -96,10 +96,10 @@ class TestDataQualityOperator(unittest.TestCase):
             from {{ table_fullname }}
         """
         rules = [
-            {"name": "not_null", "column": "dst", "time_filter": "created_at"},
-            {"name": "gt", "column": "price", "value": 10, "time_filter": "created_at"},
-            {"name": "sql", "sql": sql, "description": "test sql rule"},
-            {"name": "not", "column": "src", "value": "dst"},
+            {"type": "not_null", "column": "dst", "time_filter": "created_at"},
+            {"type": "gt", "column": "price", "value": 10, "time_filter": "created_at"},
+            {"type": "sql", "sql": sql, "description": "test sql rule"},
+            {"type": "not", "column": "src", "value": "dst"},
         ]
         self.contessa_runner.run(
             check_table={"schema_name": "tmp", "table_name": self.tmp_table_name},
@@ -149,8 +149,8 @@ class TestDataQualityOperator(unittest.TestCase):
                 timestamptz '{{task_ts}}' + INTERVAL '1 hour'
         """
         rules = [
-            {"name": "not_null", "column": "dst", "time_filter": "created_at"},
-            {"name": "sql", "sql": sql, "description": "test sql rule"},
+            {"type": "not_null", "column": "dst", "time_filter": "created_at"},
+            {"type": "sql", "sql": sql, "description": "test sql rule"},
         ]
         self.contessa_runner.run(
             check_table={"schema_name": "tmp", "table_name": self.tmp_table_name},
@@ -179,7 +179,7 @@ class TestDataQualityOperator(unittest.TestCase):
         self.assertEqual(sql_rule["attribute"], None)
 
     def test_result_table_without_prefix(self):
-        rules = [{"name": "not_null", "column": "dst", "time_filter": "created_at"}]
+        rules = [{"type": "not_null", "column": "dst", "time_filter": "created_at"}]
         self.contessa_runner.run(
             check_table={"schema_name": "tmp", "table_name": self.tmp_table_name},
             result_table={
@@ -198,7 +198,7 @@ class TestDataQualityOperator(unittest.TestCase):
         self.assertEqual(rows.shape[0], 1)
 
     def test_different_schema(self):
-        rules = [{"name": "not_null", "column": "dst", "time_filter": "created_at"}]
+        rules = [{"type": "not_null", "column": "dst", "time_filter": "created_at"}]
         self.contessa_runner.run(
             check_table={"schema_name": "tmp", "table_name": self.tmp_table_name},
             result_table={"schema_name": "hello", "table_name": "abcde"},

--- a/test/unit/test_normalizer.py
+++ b/test/unit/test_normalizer.py
@@ -11,36 +11,37 @@ from contessa.normalizer import RuleNormalizer
         (
             [
                 {
-                    "name": "not_null",
+                    "type": "n",
+                    "type": "not_null",
                     "columns": ["a", "b", "c"],
                     "separate_time_filters": ["c", "u"],
                 }
             ],
             [
-                {"name": "not_null", "column": "a", "time_filter": "c"},
-                {"name": "not_null", "column": "b", "time_filter": "c"},
-                {"name": "not_null", "column": "c", "time_filter": "c"},
-                {"name": "not_null", "column": "a", "time_filter": "u"},
-                {"name": "not_null", "column": "b", "time_filter": "u"},
-                {"name": "not_null", "column": "c", "time_filter": "u"},
+                {"type": "n", "type": "not_null", "column": "a", "time_filter": "c"},
+                {"type": "n", "type": "not_null", "column": "b", "time_filter": "c"},
+                {"type": "n", "type": "not_null", "column": "c", "time_filter": "c"},
+                {"type": "n", "type": "not_null", "column": "a", "time_filter": "u"},
+                {"type": "n", "type": "not_null", "column": "b", "time_filter": "u"},
+                {"type": "n", "type": "not_null", "column": "c", "time_filter": "u"},
             ],
         ),
         (
-            [{"name": "not_null", "columns": ["a", "b"]}],
+            [{"type": "n", "type": "not_null", "columns": ["a", "b"]}],
             [
-                {"name": "not_null", "column": "a", "time_filter": None},
-                {"name": "not_null", "column": "b", "time_filter": None},
+                {"type": "n", "type": "not_null", "column": "a", "time_filter": None},
+                {"type": "n", "type": "not_null", "column": "b", "time_filter": None},
             ],
         ),
         (
-            [{"name": "not_null", "column": "a", "time_filter": "a"}],
-            [{"name": "not_null", "column": "a", "time_filter": "a"}],
+            [{"type": "n", "type": "not_null", "column": "a", "time_filter": "a"}],
+            [{"type": "n", "type": "not_null", "column": "a", "time_filter": "a"}],
         ),
     ],
 )
 def test_normalizer(rules_def, normalized):
     results = RuleNormalizer().normalize(rules_def)
-    op = operator.itemgetter("name", "column", "time_filter")
+    op = operator.itemgetter("type", "type", "column", "time_filter")
     expected = sorted(normalized, key=op)
     results_sorted = sorted(results, key=op)
     assert expected == results_sorted
@@ -48,7 +49,7 @@ def test_normalizer(rules_def, normalized):
 
 def test_normalizer_separate_time_filters_bad_format():
     rules_def = [
-        {"name": "not_null", "column": "a", "separate_time_filters": [{"column": "c"}]}
+        {"type": "not_null", "column": "a", "separate_time_filters": [{"column": "c"}]}
     ]
     with pytest.raises(ValueError):
         results = RuleNormalizer().normalize(rules_def)
@@ -60,7 +61,7 @@ def test_normalizer_separate_time_filters_bad_format():
         (
             [
                 {
-                    "name": "not_null",
+                    "type": "not_null",
                     "column": "a",
                     "separate_time_filters": [
                         {"column": "a", "days": 10},
@@ -70,17 +71,17 @@ def test_normalizer_separate_time_filters_bad_format():
             ],
             [
                 {
-                    "name": "not_null",
+                    "type": "not_null",
                     "column": "a",
                     "time_filter": [{"column": "a", "days": 10}],
                 },
-                {"name": "not_null", "column": "a", "time_filter": [{"column": "b"}]},
+                {"type": "not_null", "column": "a", "time_filter": [{"column": "b"}]},
             ],
         ),
         (
             [
                 {
-                    "name": "not_null",
+                    "type": "not_null",
                     "column": "a",
                     "separate_time_filters": [
                         {"column": "a", "days": 10},
@@ -90,12 +91,12 @@ def test_normalizer_separate_time_filters_bad_format():
             ],
             [
                 {
-                    "name": "not_null",
+                    "type": "not_null",
                     "column": "a",
                     "time_filter": [{"column": "a", "days": 10}],
                 },
                 {
-                    "name": "not_null",
+                    "type": "not_null",
                     "column": "a",
                     "time_filter": [{"column": "b", "days": 5}],
                 },
@@ -106,7 +107,7 @@ def test_normalizer_separate_time_filters_bad_format():
 def test_normalizer_separate_time_filters(rules_def, normalized):
     def sort_rules(rule):
         return (
-            rule["name"],
+            rule["type"],
             rule["column"],
             rule["time_filter"][0]["column"]
             if isinstance(rule["time_filter"], list)
@@ -125,7 +126,7 @@ def test_normalizer_separate_time_filters(rules_def, normalized):
         (
             [
                 {
-                    "name": "not_null",
+                    "type": "not_null",
                     "columns": ["a", "b", "c"],
                     "condition": "d IN ('start', 'stay_end', 'stopover_end')",
                     "time_filter": None,
@@ -133,19 +134,19 @@ def test_normalizer_separate_time_filters(rules_def, normalized):
             ],
             [
                 {
-                    "name": "not_null",
+                    "type": "not_null",
                     "column": "a",
                     "condition": "d IN ('start', 'stay_end', 'stopover_end')",
                     "time_filter": None,
                 },
                 {
-                    "name": "not_null",
+                    "type": "not_null",
                     "column": "b",
                     "condition": "d IN ('start', 'stay_end', 'stopover_end')",
                     "time_filter": None,
                 },
                 {
-                    "name": "not_null",
+                    "type": "not_null",
                     "column": "c",
                     "condition": "d IN ('start', 'stay_end', 'stopover_end')",
                     "time_filter": None,
@@ -156,7 +157,7 @@ def test_normalizer_separate_time_filters(rules_def, normalized):
 )
 def test_normalizer_condition(rules_def, normalized):
     results = RuleNormalizer().normalize(rules_def)
-    op = operator.itemgetter("name", "column", "condition")
+    op = operator.itemgetter("type", "column", "condition")
     expected = sorted(normalized, key=op)
     results_sorted = sorted(results, key=op)
     assert expected == results_sorted

--- a/test/unit/test_rules.py
+++ b/test/unit/test_rules.py
@@ -12,7 +12,8 @@ def test_rule_context_formatted_in_where():
             return "select a, b, c from {{table_fullname}}_{{ts_nodash}}"
 
     r = TestRule(
-        name="test_rule",
+        name="test_rule_name",
+        type="test_rule_type",
         condition="created_at >= '{{ts_nodash}}'::timestamptz - interval '10 minutes'",
         description="Greater than 0 when bags <> 0",
     )

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -6,7 +6,7 @@ from contessa.rules import GtRule, NotNullRule
 
 def test_build_rules(dummy_contessa):
     rules = [
-        {"name": "not_null", "columns": ["a", "b", "c"], "time_filter": "created_at"}
+        {"type": "not_null", "columns": ["a", "b", "c"], "time_filter": "created_at"}
     ]
     normalized_rules = dummy_contessa.normalize_rules(rules)
     rules = dummy_contessa.build_rules(normalized_rules)
@@ -23,7 +23,7 @@ def test_build_rules(dummy_contessa):
 
 @pytest.mark.parametrize(
     "rule_def, rule_cls",
-    [({"name": "not_null"}, NotNullRule), ({"name": "gt"}, GtRule)],
+    [({"type": "not_null"}, NotNullRule), ({"type": "gt"}, GtRule)],
 )
 def test_pick_rule(rule_def, rule_cls, dummy_contessa):
     assert dummy_contessa.pick_rule_cls(rule_def) == rule_cls
@@ -32,7 +32,7 @@ def test_pick_rule(rule_def, rule_cls, dummy_contessa):
 def test_not_known_rule(dummy_contessa):
     msg = "I dont know this kind of rule .*"
     with pytest.raises(ValueError, match=msg):
-        dummy_contessa.pick_rule_cls({"name": "aa"})
+        dummy_contessa.pick_rule_cls({"type": "aa"})
 
 
 def test_generic_typ_qc_class(dummy_contessa):


### PR DESCRIPTION
- add type to input and replace all using of name to type

not sure about sending 'name' parameter to all Rules classes because it is used only in __str__ method and does not change any logic there 

not sure about if 'name' param should be mandatory

